### PR TITLE
Perf tweaks

### DIFF
--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -93,11 +93,12 @@ LOG = logging.getLogger(__name__)
 class Client(object):
 
     def __init__(self, host, version, username, password, port=None,
-                 protocol="https", max_retries=3, timeout=None, retry_errno_list=None):
+                 protocol="https", max_retries=3, timeout=5, retry_errno_list=None):
         self._version = self._just_digits(version)
         if self._version not in acos_client.AXAPI_VERSIONS:
             raise acos_errors.ACOSUnsupportedVersion()
         self.max_retries = max_retries  # number of attempts to connect before giving up.
+        self.timeout = timeout  # give up after waiting this long for any data from remote device.
         self.host = host
         self.port = port
         self.http = VERSION_IMPORTS[self._version]['http'].HttpClient(

--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -98,25 +98,22 @@ class Client(object):
             version,           # either 21 or 30
             username,          # username to use for authenticating to the A10 device
             password,          # password to use for authenticating to the A10 device
+            max_retries=3,     # number of times to retry a connection before giving up
             port=None,         # TCP port to use for connecting to the A10 device
             protocol="https",  # transport protocol - http or https, encryption recommended
-            max_retries=3,     # number of times to retry a connection before giving up
-            timeout=5,         # seconds to wait for return data before giving up
-            retry_errno_list=None
+            timeout=5          # seconds to wait for return data before giving up
     ):
         self._version = self._just_digits(version)
         if self._version not in acos_client.AXAPI_VERSIONS:
             raise acos_errors.ACOSUnsupportedVersion()
-        self.max_retries = max_retries  # number of attempts to connect before giving up.
-        self.timeout = timeout  # give up after waiting this long for any data from remote device.
+        self.max_retries = max_retries
+        self.timeout = timeout
         self.host = host
         self.port = port
         self.http = VERSION_IMPORTS[self._version]['http'].HttpClient(
-            host, port, protocol, timeout=timeout, max_retries=self.max_retries, retry_errno_list=retry_errno_list
+            host, port, protocol, max_retries=self.max_retries, timeout=timeout
         )
-        self.session = VERSION_IMPORTS[self._version]['Session'](
-            self, username, password
-        )
+        self.session = VERSION_IMPORTS[self._version]['Session'](self, username, password)
         self.current_partition = 'shared'
 
     def _just_digits(self, s):

--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -93,16 +93,19 @@ LOG = logging.getLogger(__name__)
 class Client(object):
 
     def __init__(self, host, version, username, password, port=None,
-                 protocol="https", timeout=None, retry_errno_list=None):
+                 protocol="https", max_retries=3, timeout=None, retry_errno_list=None):
         self._version = self._just_digits(version)
         if self._version not in acos_client.AXAPI_VERSIONS:
             raise acos_errors.ACOSUnsupportedVersion()
+        self.max_retries = max_retries  # number of attempts to connect before giving up.
         self.host = host
         self.port = port
         self.http = VERSION_IMPORTS[self._version]['http'].HttpClient(
-            host, port, protocol, timeout=timeout, retry_errno_list=retry_errno_list)
+            host, port, protocol, timeout=timeout, max_retries=self.max_retries, retry_errno_list=retry_errno_list
+        )
         self.session = VERSION_IMPORTS[self._version]['Session'](
-            self, username, password)
+            self, username, password
+        )
         self.current_partition = 'shared'
 
     def _just_digits(self, s):

--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -92,8 +92,18 @@ LOG = logging.getLogger(__name__)
 
 class Client(object):
 
-    def __init__(self, host, version, username, password, port=None,
-                 protocol="https", max_retries=3, timeout=5, retry_errno_list=None):
+    def __init__(
+            self,
+            host,              # ip address or name of the A10 device
+            version,           # either 21 or 30
+            username,          # username to use for authenticating to the A10 device
+            password,          # password to use for authenticating to the A10 device
+            port=None,         # TCP port to use for connecting to the A10 device
+            protocol="https",  # transport protocol - http or https, encryption recommended
+            max_retries=3,     # number of times to retry a connection before giving up
+            timeout=5,         # seconds to wait for return data before giving up
+            retry_errno_list=None
+    ):
         self._version = self._just_digits(version)
         if self._version not in acos_client.AXAPI_VERSIONS:
             raise acos_errors.ACOSUnsupportedVersion()

--- a/acos_client/client.py
+++ b/acos_client/client.py
@@ -159,7 +159,7 @@ class Client(object):
     @property
     def route(self):
         return VERSION_IMPORTS[self._version]["RIB"](self)
-    
+
     @property
     def vrrpa(self):
         return VERSION_IMPORTS[self._version]["VRRPA"](self)

--- a/acos_client/logutils.py
+++ b/acos_client/logutils.py
@@ -30,9 +30,8 @@ def clean(data, field=None):
 
     if type(data) is dict:
         return type(data)(
-            (x, clean(y, field=x))
-            for x, y in six.iteritems(data)
-            )
+            (x, clean(y, field=x)) for x, y in six.iteritems(data)
+        )
     elif isinstance(data, six.string_types):
         return data
     elif isinstance(data, (list, tuple)):

--- a/acos_client/tests/unit/test_client.py
+++ b/acos_client/tests/unit/test_client.py
@@ -41,11 +41,13 @@ class TestClient(unittest.TestCase):
     def test_max_retries_v21(self):
 
         self.assertEqual(self.client_21.max_retries, 5)
+        self.assertEqual(self.client_21.timeout, 3)
         self.assertEqual(self.client_21.http.max_retries, 5)
         self.assertEqual(self.client_21.http.timeout, 3)
 
     def test_max_retries_v30(self):
 
         self.assertEqual(self.client_30.max_retries, 6)
+        self.assertEqual(self.client_30.timeout, 4)
         self.assertEqual(self.client_30.http.max_retries, 6)
         self.assertEqual(self.client_30.http.timeout, 4)

--- a/acos_client/tests/unit/test_client.py
+++ b/acos_client/tests/unit/test_client.py
@@ -26,8 +26,8 @@ from acos_client import client
 class TestClient(unittest.TestCase):
 
     def setUp(self):
-        self.client_21 = client.Client('fake-host', '2.1', 'fake-username', 'fake-password')
-        self.client_30 = client.Client('fake-host', '3.0', 'fake-username', 'fake-password')
+        self.client_21 = client.Client('fake-host', '2.1', 'fake-username', 'fake-password', max_retries=5)
+        self.client_30 = client.Client('fake-host', '3.0', 'fake-username', 'fake-password', max_retries=6)
 
     def test_dns_v21(self):
         from acos_client.v21.dns import DNS
@@ -38,3 +38,13 @@ class TestClient(unittest.TestCase):
         from acos_client.v30.dns import DNS
 
         self.assertIsInstance(self.client_30.dns, DNS)
+
+    def test_max_retries_v21(self):
+
+        self.assertEqual(self.client_21.max_retries, 5)
+        self.assertEqual(self.client_21.http.max_retries, 5)
+
+    def test_max_retries_v30(self):
+
+        self.assertEqual(self.client_30.max_retries, 6)
+        self.assertEqual(self.client_30.http.max_retries, 6)

--- a/acos_client/tests/unit/test_client.py
+++ b/acos_client/tests/unit/test_client.py
@@ -12,22 +12,21 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
+
+from acos_client import client
 
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
 
-from acos_client import client
-
 
 class TestClient(unittest.TestCase):
 
     def setUp(self):
-        self.client_21 = client.Client('fake-host', '2.1', 'fake-username', 'fake-password', max_retries=5)
-        self.client_30 = client.Client('fake-host', '3.0', 'fake-username', 'fake-password', max_retries=6)
+        self.client_21 = client.Client('fake-host', '2.1', 'fake-username', 'fake-password', max_retries=5, timeout=3)
+        self.client_30 = client.Client('fake-host', '3.0', 'fake-username', 'fake-password', max_retries=6, timeout=4)
 
     def test_dns_v21(self):
         from acos_client.v21.dns import DNS
@@ -43,8 +42,10 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(self.client_21.max_retries, 5)
         self.assertEqual(self.client_21.http.max_retries, 5)
+        self.assertEqual(self.client_21.http.timeout, 3)
 
     def test_max_retries_v30(self):
 
         self.assertEqual(self.client_30.max_retries, 6)
         self.assertEqual(self.client_30.http.max_retries, 6)
+        self.assertEqual(self.client_30.http.timeout, 4)

--- a/acos_client/tests/unit/test_logutils.py
+++ b/acos_client/tests/unit/test_logutils.py
@@ -93,25 +93,46 @@ class TestLogutils(unittest.TestCase):
 
     def test_tuple_dict(self):
         actual = target.clean(
-            (1, {'credentials': {
-                'username': 'admin',
-                'password': 'secret'}
-            }))
-        expected = (1, {'credentials': {
-            'username': target.REPLACEMENT,
-            'password': target.REPLACEMENT}
-            })
+            (
+                1,
+                {
+                    'credentials': {
+                        'username': 'admin',
+                        'password': 'secret'
+                    }
+                }
+            )
+        )
+        expected = (
+            1,
+            {
+                'credentials': {
+                    'username': target.REPLACEMENT,
+                    'password': target.REPLACEMENT
+                }
+            }
+        )
         self.assertEqual(expected, actual)
 
     def test_list_dict(self):
         actual = target.clean(
-            [{'credentials': {
-                'username': 'admin',
-                'password': 'secret'}}])
-        expected = [{'credentials': {
-            'username': target.REPLACEMENT,
-            'password': target.REPLACEMENT}
-            }]
+            [
+                {
+                    'credentials': {
+                        'username': 'admin',
+                        'password': 'secret'
+                    }
+                }
+            ]
+        )
+        expected = [
+            {
+                'credentials': {
+                    'username': target.REPLACEMENT,
+                    'password': target.REPLACEMENT
+                }
+            }
+        ]
         self.assertEqual(expected, actual)
 
     def test_int(self):

--- a/acos_client/tests/unit/v21/test_system.py
+++ b/acos_client/tests/unit/v21/test_system.py
@@ -54,7 +54,7 @@ class TestHighAvailability(unittest.TestCase):
                 'software_version': '2.7.1-P3-AWS(build: 4)',
                 'startup_mode': 'hard disk primary',
                 'technical_support': 'www.a10networks.com/support '
-                }
+            }
         }
         responses.add(responses.GET, SYS_INFO_URL, json=json_response, status=200)
 

--- a/acos_client/tests/unit/v30/test_vlan.py
+++ b/acos_client/tests/unit/v30/test_vlan.py
@@ -38,8 +38,9 @@ class TestVlan(unittest.TestCase):
 
     def test_interface_get(self):
         self.target.get(self.vlan_id)
-        self.client.http.request.assert_called_with("GET", '{0}/{1}'.format(self.url_prefix,
-            self.vlan_id), {}, mock.ANY)
+        self.client.http.request.assert_called_with(
+            "GET", '{0}/{1}'.format(self.url_prefix, self.vlan_id), {}, mock.ANY
+        )
 
     def test_vlan_create_shared(self):
         self.target.create(self.vlan_id, shared_vlan=True, untagged_eths=[], untagged_trunks=[],
@@ -57,7 +58,7 @@ class TestVlan(unittest.TestCase):
                            tagged_eths=[], tagged_trunks=[], veth=False, lif=None)
 
         ep = self.expected_payload
-        ep['vlan']['untagged-eth-list'] = untagged_eths 
+        ep['vlan']['untagged-eth-list'] = untagged_eths
         self.client.http.request.assert_called_with("POST", self.url_prefix,
                                                     ep, mock.ANY)
 
@@ -69,18 +70,18 @@ class TestVlan(unittest.TestCase):
                            tagged_trunks=[], veth=None, lif=None)
 
         ep = self.expected_payload
-        ep['vlan']['untagged-trunk-list'] = untagged_trunks 
+        ep['vlan']['untagged-trunk-list'] = untagged_trunks
         self.client.http.request.assert_called_with("POST", self.url_prefix,
                                                     ep, mock.ANY)
 
     def test_vlan_create_tagged_eths(self):
         tagged_eths = [{'tagged-ethernet-start': 2, 'tagged-ethernet-end': 2}]
-        vlan._build_range_list = mock.Mock(return_value={'tagged-eth-list': tagged_eths}) 
+        vlan._build_range_list = mock.Mock(return_value={'tagged-eth-list': tagged_eths})
         self.target.create(self.vlan_id, shared_vlan=False, untagged_eths=[], untagged_trunks=[],
                            tagged_eths=[2], tagged_trunks=[], veth=False, lif=None)
 
         ep = self.expected_payload
-        ep['vlan']['tagged-eth-list'] = tagged_eths 
+        ep['vlan']['tagged-eth-list'] = tagged_eths
         self.client.http.request.assert_called_with("POST", self.url_prefix,
                                                     ep, mock.ANY)
 
@@ -91,7 +92,7 @@ class TestVlan(unittest.TestCase):
                            tagged_eths=[], tagged_trunks=[2], veth=False, lif=None)
 
         ep = self.expected_payload
-        ep['vlan']['tagged-trunk-list'] = tagged_trunks 
+        ep['vlan']['tagged-trunk-list'] = tagged_trunks
         self.client.http.request.assert_called_with("POST", self.url_prefix,
                                                     ep, mock.ANY)
 
@@ -115,6 +116,6 @@ class TestVlan(unittest.TestCase):
 
     def test_vlan_delete(self):
         self.target.delete(self.vlan_id)
-        self.client.http.request.assert_called_with("DELETE",
-            '{0}/{1}'.format(self.url_prefix,self.vlan_id), mock.ANY, mock.ANY)
-
+        self.client.http.request.assert_called_with(
+            "DELETE", '{0}/{1}'.format(self.url_prefix, self.vlan_id), mock.ANY, mock.ANY
+        )

--- a/acos_client/tests/unit/v30/test_vrrpa.py
+++ b/acos_client/tests/unit/v30/test_vrrpa.py
@@ -46,7 +46,7 @@ class TestVRID(unittest.TestCase):
 
     def test_vrid_get(self):
         self.target.get(0)
-        self.client.http.request.assert_called_with("GET", self.url_prefix+'0', {}, mock.ANY)
+        self.client.http.request.assert_called_with("GET", self.url_prefix + '0', {}, mock.ANY)
 
     def test_vrid_create_threshold(self):
         self.target.create(4, threshold=2)
@@ -61,9 +61,9 @@ class TestVRID(unittest.TestCase):
     def test_vrid_update_threshold(self):
         self.target.update(4, threshold=2)
         self.client.http.request.assert_called_with(
-            "PUT", self.url_prefix+'4', self.expected_payload(4, threshold=2), mock.ANY)
+            "PUT", self.url_prefix + '4', self.expected_payload(4, threshold=2), mock.ANY)
 
     def test_vrid_update_disable(self):
         self.target.update(4, disable=1)
         self.client.http.request.assert_called_with(
-            "PUT", self.url_prefix+'4', self.expected_payload(4, disable=1), mock.ANY)
+            "PUT", self.url_prefix + '4', self.expected_payload(4, disable=1), mock.ANY)

--- a/acos_client/v21/axapi_http.py
+++ b/acos_client/v21/axapi_http.py
@@ -143,8 +143,8 @@ class HttpClient(object):
             device_response = session_request(
                 self.url_base + api_url, verify=False, data=payload, headers=self.HEADERS)
         except (Exception) as e:
-            LOG.error("acos_client failing with error %s after 60 retries",
-                      e.__class__.__name__)
+            LOG.error("acos_client failing with error %s after %s retries",
+                      e.__class__.__name__, max_retries)
             raise e
         finally:
             session.close()

--- a/acos_client/v21/base.py
+++ b/acos_client/v21/base.py
@@ -41,8 +41,7 @@ class BaseV21(object):
         except acos_errors.MemoryFault as e:
             if retry_count < 5:
                 time.sleep(0.1)
-                return self._request(method, action, params, retry_count+1,
-                                     **kwargs)
+                return self._request(method, action, params, retry_count + 1, **kwargs)
             raise e
         except acos_errors.InvalidSessionID as e:
             if retry_count < 5:
@@ -53,8 +52,7 @@ class BaseV21(object):
                     self.client.partition.active(p)
                 except Exception:
                     pass
-                return self._request(method, action, params, retry_count+1,
-                                     **kwargs)
+                return self._request(method, action, params, retry_count + 1, **kwargs)
             raise e
 
     def _get(self, action, params={}, **kwargs):

--- a/acos_client/v21/license_manager.py
+++ b/acos_client/v21/license_manager.py
@@ -19,7 +19,7 @@ from acos_client.v21 import base
 
 class LicenseManager(base.BaseV21):
     """v2.1 LicenseManager is not yet supported"""
-    def create(self, host_list=[], serial=None, instance_name=None,  use_mgmt_port=False,
+    def create(self, host_list=[], serial=None, instance_name=None, use_mgmt_port=False,
                interval=None, bandwidth_base=None, bandwidth_unrestricted=None):
         raise NotImplementedError("LicenseManager is not yet supported using AXAPI v2.1")
 
@@ -29,6 +29,6 @@ class LicenseManager(base.BaseV21):
     def connect(self, connect=False):
         raise NotImplementedError("LicenseManager is not yet supported using AXAPI v2.1")
 
-    def update(self, host_list=[], serial=None, instance_name=None,  use_mgmt_port=False,
+    def update(self, host_list=[], serial=None, instance_name=None, use_mgmt_port=False,
                interval=None, bandwidth_base=None, bandwidth_unrestricted=None):
         raise NotImplementedError("LicenseManager is not yet supported using AXAPI v2.1")

--- a/acos_client/v21/slb/port.py
+++ b/acos_client/v21/slb/port.py
@@ -49,4 +49,4 @@ class Port(base.BaseV21):
         self._set("slb.server.port.delete", name, port_num, protocol, **kwargs)
 
     def all_delete(self, name, **kwargs):
-        self._get("slb.server.port.deleteAll",  {"name": name}, **kwargs)
+        self._get("slb.server.port.deleteAll", {"name": name}, **kwargs)

--- a/acos_client/v21/vrrp_a/__init__.py
+++ b/acos_client/v21/vrrp_a/__init__.py
@@ -17,9 +17,10 @@ from __future__ import unicode_literals
 
 import acos_client.v21.base as base
 
-from acos_client.v21.vrrp_a.vrrp_global import VRRPAGlobal 
-from acos_client.v21.vrrp_a.interface import VRRPAInterface
 from acos_client.v21.vrrp_a.failover import VRRPAFailoverPolicy
+from acos_client.v21.vrrp_a.interface import VRRPAInterface
+from acos_client.v21.vrrp_a.vrrp_global import VRRPAGlobal
+
 
 class VRRPA(base.BaseV21):
     # For status args
@@ -34,4 +35,3 @@ class VRRPA(base.BaseV21):
     @property
     def failover_policy(self):
         return VRRPAFailoverPolicy(self.client)
-

--- a/acos_client/v21/vrrp_a/failover.py
+++ b/acos_client/v21/vrrp_a/failover.py
@@ -14,12 +14,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from acos_client import multipart
-from acos_client.v21.action import Action
-from acos_client.v21.admin import Admin
 from acos_client.v21 import base
-
-import six
 
 
 class VRRPAFailoverPolicy(base.BaseV21):

--- a/acos_client/v21/vrrp_a/interface.py
+++ b/acos_client/v21/vrrp_a/interface.py
@@ -16,7 +16,6 @@ from __future__ import unicode_literals
 
 from acos_client.v21 import base
 
-import six
 
 class VRRPAInterface(base.BaseV21):
     def get_all(self, **kwargs):

--- a/acos_client/v21/vrrp_a/vrrp_global.py
+++ b/acos_client/v21/vrrp_a/vrrp_global.py
@@ -16,16 +16,14 @@ from __future__ import unicode_literals
 
 from acos_client.v21 import base
 
-import six
-
 
 class VRRPAGlobal(base.BaseV21):
     def get(self, **kwargs):
         return self._get("vrrp_a.get", **kwargs)
 
-    def set(self, status, device_id, set_id, default_vrid, hello_interval, dead_timer, 
-            track_event_delay, preemption_delay, arp_retry, 
-            vrid_list={}, 
+    def set(self, status, device_id, set_id, default_vrid, hello_interval, dead_timer,
+            track_event_delay, preemption_delay, arp_retry,
+            vrid_list={},
             preferred_session_sync_port_list={}):
         params = {
             "vrrp_a": {
@@ -45,7 +43,7 @@ class VRRPAGlobal(base.BaseV21):
 
         if vrids:
             params["vrrp_a"]["vrid_list"] = vrids
-        
+
         if sync_ports:
             params["vrrp_a"]["preferred_session_sync_port_list"] = sync_ports
 
@@ -56,4 +54,3 @@ class VRRPAGlobal(base.BaseV21):
 
     def _convert_sync_port_list(self, sync_ports):
         return sync_ports
-

--- a/acos_client/v30/action.py
+++ b/acos_client/v30/action.py
@@ -40,7 +40,6 @@ class Action(base.BaseV30):
     def activate_and_write(self, partition, **kwargs):
         self.write_memory()
 
-
     def clideploy(self, commandlist, **kwargs):
         payload = {
             "commandlist": commandlist

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -38,8 +38,7 @@ class HttpClient(object):
         "User-Agent": "ACOS-Client-AGENT-%s" % acos_client.VERSION,
     }
 
-    def __init__(self, host, port=None, protocol="https", timeout=None,
-                 retry_errno_list=None):
+    def __init__(self, host, port=None, protocol="https", max_retries=3, timeout=None, retry_errno_list=None):
         if port is None:
             if protocol is 'http':
                 self.port = 80
@@ -49,6 +48,7 @@ class HttpClient(object):
             self.port = port
 
         self.url_base = "%s://%s:%s" % (protocol, host, self.port)
+        self.max_retries = max_retries  # number of attempts to connect before giving up.
 
     def request(self, method, api_url, params={}, headers=None,
                 file_name=None, file_content=None, axapi_args=None, **kwargs):
@@ -75,16 +75,18 @@ class HttpClient(object):
 
         if (file_name is None and file_content is not None) or \
            (file_name is not None and file_content is None):
-            raise ValueError("file_name and file_content must both be "
-                             "populated if one is")
+            raise ValueError("file_name and file_content must both be populated if one is")
+
+        if "max_retries" in kwargs:
+            max_retries = kwargs['max_retries']
+        else:
+            max_retries = self.max_retries
 
         # Set "headers" variable for the request
         request_headers = self.HEADERS.copy()
         if headers:
             request_headers.update(headers)
-        LOG.debug("axapi_http: headers = %s", json.dumps(
-            logutils.clean(request_headers), indent=4)
-            )
+        LOG.debug("axapi_http: headers = %s", json.dumps(logutils.clean(request_headers), indent=4))
 
         # Process files if passed as a parameter
         if file_name is not None:
@@ -98,9 +100,9 @@ class HttpClient(object):
         # Create session to set HTTPAdapter or SSLAdapter and set max_retries
         session = Session()
         if self.port == 443:
-            session.mount('https://', HTTPAdapter(max_retries=60))
+            session.mount('https://', HTTPAdapter(max_retries=max_retries))
         else:
-            session.mount('http://', HTTPAdapter(max_retries=60))
+            session.mount('http://', HTTPAdapter(max_retries=max_retries))
         session_request = getattr(session, method.lower())
 
         # Make actual request and handle any errors
@@ -112,8 +114,8 @@ class HttpClient(object):
                 device_response = session_request(
                     self.url_base + api_url, verify=False, data=payload, headers=request_headers)
         except (Exception) as e:
-            LOG.error("acos_client failing with error %s after 60 retries",
-                      e.__class__.__name__)
+            LOG.error("acos_client failing with error %s after %s retries",
+                      e.__class__.__name__, max_retries)
             raise e
         finally:
             session.close()

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -38,7 +38,7 @@ class HttpClient(object):
         "User-Agent": "ACOS-Client-AGENT-%s" % acos_client.VERSION,
     }
 
-    def __init__(self, host, port=None, protocol="https", max_retries=3, timeout=5, retry_errno_list=None):
+    def __init__(self, host, port=None, protocol="https", max_retries=3, timeout=5):
         if port is None:
             if protocol is 'http':
                 self.port = 80
@@ -48,8 +48,8 @@ class HttpClient(object):
             self.port = port
 
         self.url_base = "%s://%s:%s" % (protocol, host, self.port)
-        self.max_retries = max_retries  # number of attempts to connect before giving up.
-        self.timeout = timeout  # give up after waiting this long for any data from remote device.
+        self.max_retries = max_retries
+        self.timeout = timeout
 
     def request(self, method, api_url, params={}, headers=None,
                 file_name=None, file_content=None, axapi_args=None, **kwargs):
@@ -78,15 +78,8 @@ class HttpClient(object):
            (file_name is not None and file_content is None):
             raise ValueError("file_name and file_content must both be populated if one is")
 
-        if "max_retries" in kwargs:
-            max_retries = kwargs['max_retries']
-        else:
-            max_retries = self.max_retries
-
-        if "timeout" in kwargs:
-            timeout = kwargs['timeout']
-        else:
-            timeout = self.timeout
+        max_retries = kwargs.get('max_retries', self.max_retries)
+        timeout = kwargs.get('timeout', self.timeout)
 
         # Set "headers" variable for the request
         request_headers = self.HEADERS.copy()
@@ -130,9 +123,7 @@ class HttpClient(object):
         # Validate json response
         try:
             json_response = device_response.json()
-            LOG.debug(
-                "axapi_http: data = %s", json.dumps(logutils.clean(json_response), indent=4)
-            )
+            LOG.debug("axapi_http: data = %s", json.dumps(logutils.clean(json_response), indent=4))
         except ValueError as e:
             # The response is not JSON but it still succeeded.
             if device_response.status_code in valid_http_codes:

--- a/acos_client/v30/axapi_http.py
+++ b/acos_client/v30/axapi_http.py
@@ -127,7 +127,7 @@ class HttpClient(object):
         except ValueError as e:
             # The response is not JSON but it still succeeded.
             if device_response.status_code in valid_http_codes:
-                return device_response.text 
+                return device_response.text
             else:
                 raise e
 

--- a/acos_client/v30/base.py
+++ b/acos_client/v30/base.py
@@ -56,8 +56,7 @@ class BaseV30(object):
                     self.client.partition.active(p)
                 except Exception:
                     pass
-                return self._request(method, action, params, retry_count+1,
-                                     **kwargs)
+                return self._request(method, action, params, retry_count + 1, **kwargs)
             raise e
 
     def _get(self, action, params={}, **kwargs):

--- a/acos_client/v30/license_manager.py
+++ b/acos_client/v30/license_manager.py
@@ -31,7 +31,7 @@ class LicenseManager(base.BaseV30):
 
     url_base = "/license-manager"
 
-    def create(self, host_list=[], serial=None, instance_name=None,  use_mgmt_port=False,
+    def create(self, host_list=[], serial=None, instance_name=None, use_mgmt_port=False,
                interval=None, bandwidth_base=None, bandwidth_unrestricted=None):
         """Creates a license manager entry
 

--- a/acos_client/v30/nat.py
+++ b/acos_client/v30/nat.py
@@ -28,12 +28,14 @@ class Nat(base.BaseV30):
 
         def _set(self, name, start_ip, end_ip, mask, **kwargs):
             params = {
-                "pool": self.minimal_dict({
-                    'pool-name': name,
-                    'start-address': start_ip,
-                    'end-address': end_ip,
-                    'netmask': mask,
-                    }),
+                "pool": self.minimal_dict(
+                    {
+                        'pool-name': name,
+                        'start-address': start_ip,
+                        'end-address': end_ip,
+                        'netmask': mask,
+                    }
+                ),
             }
             self._post(self.url_prefix + name, params, **kwargs)
 

--- a/acos_client/v30/partition.py
+++ b/acos_client/v30/partition.py
@@ -88,7 +88,7 @@ class Partition(base.BaseV30):
                 self._create(name, self._next_available_id())
                 break
             except acos_errors.PartitionIdExists:
-                time.sleep(0.05 + random.random()/100)
+                time.sleep(0.05 + random.random() / 100)
 
     def delete(self, name):
         if name == 'shared':

--- a/acos_client/v30/responses.py
+++ b/acos_client/v30/responses.py
@@ -229,7 +229,7 @@ def raise_axapi_ex(response, method, api_url):
             # Now try to find specific API method exceptions
             matched = False
             for k in x.keys():
-                if k != '*' and re.match('^'+k, api_url):
+                if k != '*' and re.match('^' + k, api_url):
                     matched = True
                     ex = x[k]
 

--- a/acos_client/v30/slb/member.py
+++ b/acos_client/v30/slb/member.py
@@ -43,7 +43,7 @@ class Member(base.BaseV30):
             name=server_name,
             port=server_port
         )
-        return self._get(url+'oper', **kwargs)
+        return self._get(url + 'oper', **kwargs)
 
     def _write(self,
                service_group_name,

--- a/acos_client/v30/vrrpa/vrid.py
+++ b/acos_client/v30/vrrpa/vrid.py
@@ -51,7 +51,7 @@ class VRID(base.BaseV30):
         return self._post(self.base_url, self._build_params(vrid_val, threshold, disable))
 
     def update(self, vrid_val, threshold=None, disable=None):
-        return self._put(self.base_url+str(vrid_val), self._build_params(vrid_val, threshold, disable))
+        return self._put(self.base_url + str(vrid_val), self._build_params(vrid_val, threshold, disable))
 
     def delete(self, vrid_val):
         return self._delete(self.base_url + str(vrid_val))

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ commands = flake8
 
 [flake8]
 #ignore = E122,E125,E126,E128,E129,E251,E265,E713,F402,F811,F812,H104,H237,H302,H304,H305,H307,H401,H402,H404,H405,H904
+ignore = H301
 show-source = true
 exclude = .venv,.git,.tox
 max-line-length = 119


### PR DESCRIPTION
Both `Client.client` and its `http` objects now support `max_retries`. The default is 3.
Both `Client.client` and its `http` objects now support `timeout`. The default is 5.

Everything else is code cleanup per what the PEP8 and flake8 messages were making noise about.